### PR TITLE
ignore separators inside quotes, fixes #7

### DIFF
--- a/lib/plugins/base.js
+++ b/lib/plugins/base.js
@@ -66,11 +66,37 @@ function cleanArtist (artist) {
     .replace(/[/\s,:;~\-–_\s"]+$/, '') // trim trailing white chars and dash
 }
 
+function inQuotes (str, idx) {
+  var openChars = '([{«'
+  var closeChars = ')]}»'
+  var toggleChars = '"\''
+  var open = {
+    ')': 0,
+    ']': 0,
+    '}': 0,
+    '»': 0,
+    '"': 0,
+    '\'': 0
+  }
+  for (var i = 0; i < idx; i++) {
+    var index = openChars.indexOf(str[i])
+    if (index !== -1) {
+      open[closeChars[index]]++
+    } else if (closeChars.indexOf(str[i]) !== -1 && open[str[i]] > 0) {
+      open[str[i]]--
+    } if (toggleChars.indexOf(str[i]) !== -1) {
+      open[str[i]] = 1 - open[str[i]]
+    }
+  }
+
+  return Object.keys(open).reduce(function (acc, k) { return acc + open[k] }, 0) > 0
+}
+
 function splitArtistTitle (str) {
   for (var i = 0, l = separators.length; i < l; i++) {
     var sep = separators[i]
     var idx = str.indexOf(sep)
-    if (idx > -1) {
+    if (idx > -1 && !inQuotes(str, idx)) {
       return [ str.slice(0, idx), str.slice(idx + sep.length) ]
     }
   }

--- a/test/jypentertainment.js
+++ b/test/jypentertainment.js
@@ -4,14 +4,10 @@ module.exports = {
   // jypentertainment uses a title format like:
   // Artist "Title" Fluff
   tests: [
-    // This one is not so fun because there is a separator inside the quotes,
-    // and separators are usually tried first. It could be worked around by
-    // only splitting on separators outside quotes, perhaps, but until then,
-    // it'll just be marked "optional" instead :')
+    // This one is not so fun because there is a separator (-) inside the quotes,
+    // and separators are usually tried first.
     { input: 'TWICE(트와이스) "OOH-AHH하게(Like OOH-AHH)" M/V',
-      expected: [ 'TWICE(트와이스)', 'OOH-AHH하게(Like OOH-AHH)' ],
-      optional: true },
-
+      expected: [ 'TWICE(트와이스)', 'OOH-AHH하게(Like OOH-AHH)' ] },
     { input: 'GOT7 "Just right(딱 좋아)" M/V',
       expected: [ 'GOT7', 'Just right(딱 좋아)' ] },
     { input: 'miss A “Only You(다른 남자 말고 너)” M/V',

--- a/test/separators.js
+++ b/test/separators.js
@@ -1,0 +1,19 @@
+module.exports = {
+  tests: [
+    // https://www.youtube.com/watch?v=dYnDCHUzzaY
+    // ":" is a possible separator, but should not be used in this case.
+    { input: 'HA:TFELT [핫펠트(예은)] "Truth" M/V',
+      // Ideal would be to include the Hangul but it's in
+      // [] which means it's deleted for now.
+      expected: [ 'HA:TFELT', 'Truth' ],
+      optional: true },
+    // https://www.youtube.com/watch?v=Qk52ypnGs68
+    // "-" is a possible separator, but should not be used in this case.
+    { input: 'T-ARA[티아라] "NUMBER NINE [넘버나인]" M/V',
+      expected: [ 'T-ARA', 'NUMBER NINE' ],
+      optional: true },
+    // https://www.youtube.com/watch?v=aeo_nWsu5cs
+    { input: '[MV] YOUNHA(윤하) _ Get It?(알아듣겠지) (Feat. HA:TFELT, CHEETAH(치타))',
+      expected: [ 'YOUNHA(윤하)', 'Get It?(알아듣겠지) (Feat. HA:TFELT, CHEETAH(치타))' ] }
+  ]
+}


### PR DESCRIPTION
this recognises things like:

`Artist "ABC-XYZ"`

correctly as:

`Artist` `ABC-XYZ`

instead of the old:

`Artist "ABC` `XYZ"`